### PR TITLE
Docker deployment of conceptarium_frontend

### DIFF
--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -8,3 +8,4 @@ streamlit==1.4.0
 Pillow==9.0.0
 extra-streamlit-components==0.1.53
 arxiv2bib==1.0.8
+click==8


### PR DESCRIPTION
While deploying with the `docker-compose up -d` command, I get the following error in the *conceptarium_frontend* container.

`AttributeError: module 'click' has no attribute 'get_os_args'`

It is resolved by adding 'click' in frontend/requirements.txt